### PR TITLE
fixing ofxEasyFft to not extend ofBaseApp but extend ofBaseSoundInput

### DIFF
--- a/src/ofxEasyFft.cpp
+++ b/src/ofxEasyFft.cpp
@@ -3,6 +3,9 @@
 ofxEasyFft::ofxEasyFft()
 :useNormalization(true) {
 }
+ofxEasyFft::~ofxEasyFft(){
+    stream.close();
+}
 
 void ofxEasyFft::setup(int bufferSize, fftWindowType windowType, fftImplementation implementation, int audioBufferSize, int audioSampleRate) {
 	if(bufferSize < audioBufferSize) {
@@ -17,7 +20,11 @@ void ofxEasyFft::setup(int bufferSize, fftWindowType windowType, fftImplementati
 	audioBack.resize(bufferSize);
 	audioRaw.resize(bufferSize);
 	
-	ofSoundStreamSetup(0, 1, this, audioSampleRate, audioBufferSize, 2);
+    stream.listDevices();
+    stream.setup(0, 1, audioSampleRate, audioBufferSize, 2);
+    stream.setInput(this);
+    
+
 }
 
 void ofxEasyFft::setUseNormalization(bool useNormalization) {
@@ -33,6 +40,10 @@ void ofxEasyFft::update() {
 	float* curFft = fft->getAmplitude();
 	copy(curFft, curFft + fft->getBinSize(), bins.begin());
 	normalize(bins);
+}
+
+void ofxEasyFft::audioReceived(ofAudioEventArgs & args){
+    audioReceived(args.buffer, args.bufferSize, args.nChannels);
 }
 
 vector<float>& ofxEasyFft::getAudio() {
@@ -55,6 +66,8 @@ void ofxEasyFft::audioReceived(float* input, int bufferSize, int nChannels) {
 	audioMiddle = audioBack;
 	soundMutex.unlock();
 }
+
+
 
 void ofxEasyFft::normalize(vector<float>& data) {
 	if(useNormalization) {

--- a/src/ofxEasyFft.h
+++ b/src/ofxEasyFft.h
@@ -1,8 +1,10 @@
+#include "ofMain.h"
 #include "ofxFft.h"
 
-class ofxEasyFft : ofBaseApp {
+class ofxEasyFft : public ofBaseSoundInput{
 public:
 	ofxEasyFft();
+    ~ofxEasyFft();
 	void setup(int bufferSize = 512,
 						 fftWindowType windowType = OF_FFT_WINDOW_HAMMING,
 						 fftImplementation implementation = OF_FFT_FFTW,
@@ -13,10 +15,11 @@ public:
 	vector<float>& getAudio();
 	vector<float>& getBins();
 	
+    void audioReceived(ofAudioEventArgs & args);
 	void audioReceived(float* input, int bufferSize, int nChannels);
 	
 	ofxFft* fft;
-	
+	ofSoundStream stream;
 private:
 	bool useNormalization;
 	ofMutex soundMutex;
@@ -24,4 +27,5 @@ private:
 	vector<float> bins;
 	
 	void normalize(vector<float>& data);
+
 };

--- a/src/ofxProcessFFT.cpp
+++ b/src/ofxProcessFFT.cpp
@@ -401,6 +401,7 @@ float ProcessFFT::getDelta(){
     return delta; //if the delta is greater than a percentage of the maximum volume, then trigger an event (delta scales to maximum volume)
 }
 
+
 float ProcessFFT::getUnScaledLoudestValue(){
     //This returns the unnormalized value of the current loudest sound - useful for detecting whether the volume input is low or really high
     return maxSound;

--- a/src/ofxProcessFFT.h
+++ b/src/ofxProcessFFT.h
@@ -14,7 +14,6 @@ public:
     
     void setup(); //whether you want your sounds in a 0-1 range or a 0-volumeRange - setting volume range doesn't matter if you're normalizing
     void update();
-    
     //For Debugging audio trends
     void drawHistoryGraph(ofPoint pt, fftRangeType drawType);
     


### PR DESCRIPTION
ofxEasyFft extends ofBaseSound and registers itself with ofSoundStream.
