### PR TITLE
Minor error in ProcessFFT

### DIFF
--- a/src/ofxProcessFFT.cpp
+++ b/src/ofxProcessFFT.cpp
@@ -5,7 +5,7 @@ void ProcessFFT::setup(){
     scaleFactor = 10000;
     numBins = 16384;
     
-    fft.setup(numBins); //default
+    fft.setup(); //default
     fft.setUseNormalization(false);
     
     graphMaxSize = 200; //approx 10sec of history at 60fps


### PR DESCRIPTION
Unless I'm mistaken I believe that the first parameter in EasyFFT.setup is the buffer size, so passing the number of bins through to that seems wrong. I've removed it. 

Seems like a great lib, I'm using it for some lasering right now :)