### PR TITLE
Adds support to initialize ofxFft processors with ofSoundStreamSettings

### DIFF
--- a/example-basic/src/ofApp.cpp
+++ b/example-basic/src/ofApp.cpp
@@ -13,14 +13,25 @@ void ofApp::setup() {
 	drawBins.resize(fft->getBinSize());
 	middleBins.resize(fft->getBinSize());
 	audioBins.resize(fft->getBinSize());
+
+	ofSoundStreamSettings settings;
+	soundStream.printDeviceList();
+	auto devices = soundStream.getMatchingDevices("default");
+	if(!devices.empty()){
+		settings.setInDevice(devices[0]);
+	}
+	settings.bufferSize = bufferSize;
+	settings.numInputChannels = 1;
+	// the rest of ofSoundStreamSetting defaults are good to go
+	soundStream.setup(settings);
+	soundStream.setInput(this);
 	
 	// 0 output channels,
 	// 1 input channel
 	// 44100 samples per second
 	// [bins] samples per buffer
 	// 4 num buffers (latency)
-	
-	ofSoundStreamSetup(0, 1, this, 44100, bufferSize, 4);
+	//ofSoundStreamSetup(0, 1, this, 44100, bufferSize, 4);
 	
 	ofBackground(0, 0, 0);
 }

--- a/example-basic/src/ofApp.h
+++ b/example-basic/src/ofApp.h
@@ -12,6 +12,7 @@ public:
 
 	int plotHeight, bufferSize;
 
+	ofSoundStream soundStream;
 	ofxFft* fft;
 	
 	ofMutex soundMutex;

--- a/example-easy/src/ofApp.cpp
+++ b/example-easy/src/ofApp.cpp
@@ -3,7 +3,17 @@
 void ofApp::setup() {
 	ofSetVerticalSync(true);	
 	ofSetFrameRate(60);
-	fft.setup(16384);
+
+	ofSoundStreamSettings settings;
+	ofSoundStream soundStream;
+	soundStream.printDeviceList();
+	auto devices = soundStream.getMatchingDevices("default");
+	if(!devices.empty()){
+		settings.setInDevice(devices[0]);
+	}
+	settings.numInputChannels = 1;
+	fft.setup(settings, 16384);
+	//fft.setup(16384);
 }
 
 void ofApp::update() {

--- a/example-eq/src/ofApp.cpp
+++ b/example-eq/src/ofApp.cpp
@@ -28,7 +28,19 @@ void ofApp::setup() {
 	appWidth = ofGetWidth();
 	appHeight = ofGetHeight();
 
-	ofSoundStreamSetup(0, 1, this, 44100, bufferSize, 4);
+	ofSoundStreamSettings settings;
+	soundStream.printDeviceList();
+	auto devices = soundStream.getMatchingDevices("default");
+	if(!devices.empty()){
+		settings.setInDevice(devices[0]);
+	}
+	settings.bufferSize = bufferSize;
+	settings.numInputChannels = 1;
+	// the rest of ofSoundStreamSetting defaults are good to go
+	soundStream.setup(settings);
+	soundStream.setInput(this);
+	
+	//ofSoundStreamSetup(0, 1, this, 44100, bufferSize, 4);
 
 	ofBackground(0, 0, 0);
 }

--- a/example-eq/src/ofApp.h
+++ b/example-eq/src/ofApp.h
@@ -17,6 +17,7 @@ public:
 
 	int plotHeight, bufferSize;
 
+	ofSoundStream soundStream;
 	ofxFft* fft;
 
 	float* audioInput;

--- a/example-process-input/src/ofApp.cpp
+++ b/example-process-input/src/ofApp.cpp
@@ -3,8 +3,17 @@
 void ofApp::setup() {
 	ofSetVerticalSync(true);	
 	ofSetFrameRate(60);
-	fft.setup();
-    
+
+	ofSoundStreamSettings settings;
+	ofSoundStream soundStream;
+	soundStream.printDeviceList();
+	auto devices = soundStream.getMatchingDevices("default");
+	if(!devices.empty()){
+		settings.setInDevice(devices[0]);
+	}
+	settings.numInputChannels = 1;
+
+	fft.setup(settings);
 }
 
 void ofApp::update() {

--- a/example-visualize/src/ofApp.cpp
+++ b/example-visualize/src/ofApp.cpp
@@ -22,13 +22,25 @@ void ofApp::setup() {
 	middleBins.resize(fft->getBinSize());
 	audioBins.resize(fft->getBinSize());
 
+	ofSoundStreamSettings settings;
+	soundStream.printDeviceList();
+	auto devices = soundStream.getMatchingDevices("default");
+	if(!devices.empty()){
+		settings.setInDevice(devices[0]);
+	}
+	//settings.setInListener(this);
+	settings.bufferSize = bufferSize;
+	settings.numInputChannels = 1;
+	// the rest of ofSoundStreamSetting defaults are good to go
+	soundStream.setup(settings);
+	soundStream.setInput(this);
+
 	// 0 output channels,
 	// 1 input channel
 	// 44100 samples per second
 	// [bins] samples per buffer
 	// 4 num buffers (latency)
-
-	ofSoundStreamSetup(0, 1, this, 44100, bufferSize, 4);
+	//ofSoundStreamSetup(0, 1, this, 44100, bufferSize, 4);
 
 	mode = SINE;
 	appWidth = ofGetWidth();

--- a/example-visualize/src/ofApp.h
+++ b/example-visualize/src/ofApp.h
@@ -15,6 +15,7 @@ public:
 
 	int plotHeight, bufferSize;
 
+	ofSoundStream soundStream;
 	ofxFft* fft;
 	
 	int spectrogramOffset;

--- a/src/ofxEasyFft.cpp
+++ b/src/ofxEasyFft.cpp
@@ -7,7 +7,8 @@ ofxEasyFft::~ofxEasyFft(){
     stream.close();
 }
 
-void ofxEasyFft::setup(int bufferSize, fftWindowType windowType, fftImplementation implementation, int audioBufferSize, int audioSampleRate) {
+void ofxEasyFft::setup(ofSoundStreamSettings settings, int bufferSize, fftWindowType windowType, fftImplementation implementation) {
+	int audioBufferSize = settings.bufferSize;
 	if(bufferSize < audioBufferSize) {
 		ofLogWarning("ofxEasyFft") << "bufferSize (" << bufferSize << ") less than audioBufferSize (" << audioBufferSize << "), using " << audioBufferSize;
 		bufferSize = audioBufferSize;
@@ -21,9 +22,26 @@ void ofxEasyFft::setup(int bufferSize, fftWindowType windowType, fftImplementati
 	audioBack.resize(bufferSize);
 	audioRaw.resize(bufferSize);
 	
-    stream.getDeviceList();
-    stream.setup(0, 1, audioSampleRate, audioBufferSize, 2);
-    stream.setInput(this);
+	stream.setup(settings);
+	//stream.setup(0, 1, audioSampleRate, audioBufferSize, 2);
+	stream.setInput(this);
+
+}
+
+void ofxEasyFft::setup(int bufferSize, fftWindowType windowType, fftImplementation implementation, int audioBufferSize, int audioSampleRate) {
+	ofSoundStreamSettings settings;
+
+	stream.printDeviceList();
+
+	auto devices = stream.getMatchingDevices("default");
+	if(!devices.empty()){
+	  settings.setInDevice(devices[0]);
+	}
+	
+	settings.sampleRate = audioSampleRate;
+	settings.bufferSize = audioBufferSize;
+	settings.numInputChannels = 1;
+	setup(settings, bufferSize, windowType, implementation);
 }
 
 void ofxEasyFft::setUseNormalization(bool useNormalization) {

--- a/src/ofxEasyFft.h
+++ b/src/ofxEasyFft.h
@@ -7,6 +7,10 @@ class ofxEasyFft : public ofBaseSoundInput{
 public:
 	ofxEasyFft();
     ~ofxEasyFft();
+  	void setup(ofSoundStreamSettings settings,
+						 int bufferSize = 512,
+						 fftWindowType windowType = OF_FFT_WINDOW_HAMMING,
+						 fftImplementation implementation = OF_FFT_BASIC);
 	void setup(int bufferSize = 512,
 						 fftWindowType windowType = OF_FFT_WINDOW_HAMMING,
 						 fftImplementation implementation = OF_FFT_BASIC,

--- a/src/ofxProcessFFT.cpp
+++ b/src/ofxProcessFFT.cpp
@@ -1,11 +1,16 @@
 #include "ofxProcessFFT.h"
 
 void ProcessFFT::setup(){
-    
+    ofSoundStreamSettings settings;
+    setup(settings);
+}
+
+//---------------------------------------------
+void ProcessFFT::setup(ofSoundStreamSettings settings) {
     scaleFactor = 10000;
     numBins = 16384;
     
-    fft.setup(numBins); //default
+    fft.setup(settings, numBins); //default
     fft.setUseNormalization(false);
     
     graphMaxSize = 200; //approx 10sec of history at 60fps
@@ -27,7 +32,6 @@ void ProcessFFT::setup(){
     
     normalize = false;
     volumeRange = 400; //only used if normalize is false
-
 }
 
 //---------------------------------------------

--- a/src/ofxProcessFFT.h
+++ b/src/ofxProcessFFT.h
@@ -13,6 +13,7 @@ public:
     ofxEasyFft fft;
     
     void setup(); //whether you want your sounds in a 0-1 range or a 0-volumeRange - setting volume range doesn't matter if you're normalizing
+    void setup(ofSoundStreamSettings settings);
     void update();
     //For Debugging audio trends
     void drawHistoryGraph(ofPoint pt, fftRangeType drawType);


### PR DESCRIPTION
This can allow selecting a different input device and also allows the app to show up as a stream in PulseAudio Volume Control's Recording tab which it didn't with older versions (so now I can easily route system audio output into openFrameworks ofxFft).

I have done only basic testing to verify all examples are working and the input device can be set through ofSoundStreamSettings.

I am looking to ofxFft because built in ofSoundGetSpectrum() does not appear to work on input sound streams.